### PR TITLE
- Added method for setup log level manually

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import "regenerator-runtime/runtime.js";
-import { info, setVerboseLog } from "./utils/log";
+import {info, setLogLevel, setVerboseLog} from "./utils/log";
 import { getGlobalConfig } from "./utils/config";
 import ProbesEngine from "./engine";
 
@@ -11,6 +11,14 @@ export default class WebRTCMetrics {
     info(moduleName, `welcome to ${this._config.name} version ${this._config.version}`);
     setVerboseLog(this._config.verbose || false);
     this._engine = new ProbesEngine(this._config);
+  }
+
+  /**
+   * Change log level manually
+   * @param level - can be one of [TRACE, DEBUG, INFO, WARN, ERROR, SILENT]
+   */
+  setupLogLevel(level){
+    setLogLevel(level);
   }
 
   /**

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -10,6 +10,16 @@ export const setVerboseLog = (shouldHaveVerboseLog) => {
   log.setLevel(shouldHaveVerboseLog ? log.levels.TRACE : log.levels.INFO);
 };
 
+export const setLogLevel = (logLevel) => {
+  const levels = [...Object.keys(log.levels)];
+  if(levels.includes(logLevel)){
+    log.info(format(getHeader(), "log         ", `update log level to ${logLevel.toLowerCase()}`));
+    log.setLevel(logLevel);
+  }else{
+    log.warn(format(getHeader(), "log","Incorrect log level please choose one of "), levels);
+  }
+}
+
 export const debug = (name, message, data) => {
   if (data) {
     log.debug(format(getHeader(), name, message), data);


### PR DESCRIPTION
Hi i wan to use your lib in our project, but we dont need many logs in console. I checked code and don see the method for setup log level to "silent" or 'warning", wich we want to use in a production, so i added this one to your lib. Please let met know if i need change something, or you have another method for set up log level. 